### PR TITLE
Dockerize parent project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.3
+
+RUN apk --update add \
+    coreutils \
+    py-setuptools \
+    ca-certificates
+
+RUN mkdir /app
+WORKDIR /app
+
+# Install code:
+COPY setup.py /app
+COPY cloudwatchmon /app/cloudwatchmon
+RUN python setup.py install
+
+# Install wrapper script:
+COPY stats.sh /app
+ENTRYPOINT [ "/app/stats.sh" ]
+

--- a/stats.sh
+++ b/stats.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+sed '1d' -i /etc/mtab && /usr/bin/mon-put-instance-stats.py \
+    --mem-util \
+    --disk-space-util \
+    --disk-path=/ \
+    --auto-scaling \
+    --auto-scaling-group=$ASG \
+    --persistent $*
+


### PR DESCRIPTION
https://github.com/pebble/docker-cloudwatch-stats made sense as a
separate project when we were using osiegmar's upstream.

Since forking, all that separate project does is make my tag more things
in order to release! Fold the Dockerfile into this project.
