### PR TITLE
NOOP `Filesystem` dimension

### DIFF
--- a/cloudwatchmon/cli/put_instance_stats.py
+++ b/cloudwatchmon/cli/put_instance_stats.py
@@ -145,7 +145,7 @@ class Metrics:
         if mount:
             common_dims['MountPath'] = mount
         if file_system:
-            common_dims['Filesystem'] = file_system
+            common_dims['Filesystem'] = '-'
 
         dims = []
 


### PR DESCRIPTION
This Dimension holds the block device for a mount point:
https://github.com/pebble/cloudwatch-mon-scripts-python/blob/master/cloudwatchmon/cli/put_instance_stats.py#L380

This is red herring information when we always run the monitoring script
in a Docker container.

We can't just _drop_ filesystem without affecting existing metrics, so
leave it "empty". (`-` is the value returned for the root partition,
`--disk-path=/` in docker).
